### PR TITLE
Multi day recipes

### DIFF
--- a/app/assets/stylesheets/_forms.scss
+++ b/app/assets/stylesheets/_forms.scss
@@ -28,6 +28,23 @@ input[type=text], input[type=number] {
   }
 }
 
+.side-by-side {
+  display: flex;
+  flex-direction: row;
+  gap: 10px;
+
+  .field:first-child {
+    flex-grow: 3;
+  }
+  .field:last-child {
+    flex-grow: 1;
+  }
+
+  .field input[type=text], input[type=number] {
+    width: 100%;
+  }
+}
+
 .input-inline-button {
   display: flex;
   .input {

--- a/app/controllers/recipes_controller.rb
+++ b/app/controllers/recipes_controller.rb
@@ -59,6 +59,7 @@ class RecipesController < ApplicationController
   def recipe_params
     params.require(:recipe).permit([
       :name,
+      :multi_day_count,
       tag_ids: [],
       leftovers_source_attributes: [
         :id,

--- a/app/views/recipes/_form.html.slim
+++ b/app/views/recipes/_form.html.slim
@@ -7,9 +7,13 @@
         - @recipe.errors.full_messages.each do |msg|
           li= msg
 
-  .field
-    .label= f.label :name
-    .input= f.text_field :name, placeholder: "Beef in Beer", autofocus: true
+  .side-by-side
+    .field
+      .label= f.label :name
+      .input= f.text_field :name, placeholder: "Beef in Beer", autofocus: true
+    .field
+      .label= f.label :multi_day_count
+      .input= f.text_field :multi_day_count
   = render "shared/tag_checkboxes", f:
   = render "leftover_fields", f:
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -54,3 +54,8 @@ en:
         recipe/leftovers_sink: *nested_leftover_format
         leftovers_source: *leftover_errors
         leftovers_sink: *leftover_errors
+
+  helpers:
+    label:
+      recipe:
+        multi_day_count: "Serves how many days?"

--- a/db/migrate/20241129212246_add_multi_day_count_to_recipe.rb
+++ b/db/migrate/20241129212246_add_multi_day_count_to_recipe.rb
@@ -1,0 +1,5 @@
+class AddMultiDayCountToRecipe < ActiveRecord::Migration[7.2]
+  def change
+    add_column :recipes, :multi_day_count, :integer, default: 1
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2024_10_07_214427) do
+ActiveRecord::Schema[7.2].define(version: 2024_11_29_212246) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -88,6 +88,7 @@ ActiveRecord::Schema[7.2].define(version: 2024_10_07_214427) do
     t.bigint "user_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.integer "multi_day_count", default: 1
     t.index ["name"], name: "index_recipes_on_name"
     t.index ["user_id"], name: "index_recipes_on_user_id"
   end

--- a/spec/factories/recipes.rb
+++ b/spec/factories/recipes.rb
@@ -1,6 +1,7 @@
 FactoryBot.define do
   factory :recipe do
     name { "Trout a la Creme" }
+    multi_day_count { 1 }
     association :user
   end
 end


### PR DESCRIPTION
Allow recipes to be marked as producing more than 1 day of meals. If such a recipe gets included in a plan, then it is automatically added to subsequent days, ignoring any tags on those days.