### PR TITLE
Tags as lozenges

### DIFF
--- a/app/assets/stylesheets/_forms.scss
+++ b/app/assets/stylesheets/_forms.scss
@@ -76,12 +76,16 @@ fieldset.checkboxes {
     }
   }
 
-  .tag-checkbox, .leftover-checkbox {
+  .tag-checkbox, .leftover-radio {
     flex: 0 0 33%;
     display: flex;
     align-items: center;
-    label {
+    .lozenge {
       margin-left: 5px;
     }
+  }
+
+  .leftover-radio {
+    margin-bottom: 2px;
   }
 }

--- a/app/assets/stylesheets/_globals.scss
+++ b/app/assets/stylesheets/_globals.scss
@@ -14,7 +14,9 @@
 
   --pale-border: #bbbbbb;
   --mid-fg-grey: #888888;
+  --dark-bg-grey: #888888;
   --mid-bg-grey: #dddddd;
+  --pale-bg-grey: #eeeeee;
   --black: #111111;
   --white: #{$white};
   --mid-red: #dd0000;

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -359,6 +359,10 @@ main#root-page {
   font-size: 14px;
   line-height: 1.5em;
   font-family: var(--main-font-stack);
+
+  &.preview {
+    margin-bottom: 10px;
+  }
 }
 
 .list .lozenge {

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -358,6 +358,7 @@ main#root-page {
   border-radius: 2em;
   font-size: 14px;
   line-height: 1.5em;
+  font-family: var(--main-font-stack);
 }
 
 .list .lozenge {
@@ -367,6 +368,7 @@ main#root-page {
 .tag-lozenge {
   background-color: var(--pale-bg-grey);
   border: 1px solid var(--black);
+  color: var(--black);
 }
 .leftover-lozenge {
   background-color: var(--dark-bg-grey);

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -245,15 +245,44 @@ main#root-page {
 
   .recipe, .tag, .leftover, .header-row {
     display: flex;
-    flex-flow: row nowrap;
+    flex-flow: row wrap;
     justify-content: space-between;
     align-items: center;
+    gap: 10px;
     width: 100%;
     padding: 8px;
+
+    .name {
+      flex-grow: 1;
+      order: 1;
+    }
+
+    .tags, .actions {
+      flex: auto 0 0;
+    }
+
+    .tags {
+      order: 2;
+    }
+
+    .actions {
+      order: 3
+    }
 
     @media screen and (max-width: 800px) {
       font-size: 1.5em;
       padding: 15px;
+
+      .actions {
+        order: 2;
+      }
+      .tags {
+        order: 3;
+        width: 100%;
+      }
+      .lozenge {
+        font-size: 18px;
+      }
     }
   }
 
@@ -277,6 +306,10 @@ main#root-page {
       padding-bottom: 0;
     }
   }
+}
+
+#recipe-list {
+  width: 70%;
 }
 
 #menu-planner {
@@ -317,4 +350,26 @@ main#root-page {
       flex-grow: 1;
     }
   }
+}
+
+.lozenge {
+  display: inline-block;
+  padding: 0 7px;
+  border-radius: 2em;
+  font-size: 14px;
+  line-height: 1.5em;
+}
+
+.list .lozenge {
+  font-size: inherit;
+}
+
+.tag-lozenge {
+  background-color: var(--pale-bg-grey);
+  border: 1px solid var(--black);
+}
+.leftover-lozenge {
+  background-color: var(--dark-bg-grey);
+  border: 1px solid var(--pale-border);
+  color: var(--white);
 }

--- a/app/javascript/controllers/lozenge_preview_controller.js
+++ b/app/javascript/controllers/lozenge_preview_controller.js
@@ -1,0 +1,14 @@
+import { Controller } from "@hotwired/stimulus"
+
+// Connects to data-controller="lozenge-preview"
+export default class extends Controller {
+  static targets = ["preview"]
+
+  connect() {
+    console.log("Preview connected")
+  }
+
+  nameChange(event) {
+    this.previewTarget.textContent = event.target.value;
+  }
+}

--- a/app/views/leftovers/_form.html.slim
+++ b/app/views/leftovers/_form.html.slim
@@ -1,4 +1,4 @@
-= form_for @leftover do |f|
+= form_for @leftover, data: { controller: "lozenge-preview" } do |f|
   - if @leftover.errors.any?
     #error_explanation
       h2
@@ -7,9 +7,11 @@
         - @leftover.errors.full_messages.each do |msg|
           li= msg
 
+  .preview.leftover-lozenge.lozenge data-lozenge-preview-target="preview" = @leftover.name.presence || "preview"
+
   .field
     .label= f.label :name, "Kind"
-    .input= f.text_field :name, placeholder: "beef", autofocus: true
+    .input= f.text_field :name, placeholder: "beef", autofocus: true, data: { action: "lozenge-preview#nameChange" }
 
   .button-area
     - if !@leftover.persisted?

--- a/app/views/leftovers/_leftover.html.slim
+++ b/app/views/leftovers/_leftover.html.slim
@@ -1,6 +1,6 @@
 - new_leftover_id ||= nil
 .leftover id=dom_id(leftover) class=("new" if leftover.id == new_leftover_id)
-  .field.name id=dom_id(leftover, "name") = leftover.name
+  .field.name.leftover-lozenge.lozenge id=dom_id(leftover, "name") = leftover.name
   .field.actions
     = link_to edit_leftover_path(leftover), id: dom_id(leftover, "edit"), class: "icon", data: { turbo_frame: "modal" }
       i.fa-solid.fa-pen

--- a/app/views/leftovers/_leftover.html.slim
+++ b/app/views/leftovers/_leftover.html.slim
@@ -1,6 +1,7 @@
 - new_leftover_id ||= nil
 .leftover id=dom_id(leftover) class=("new" if leftover.id == new_leftover_id)
-  .field.name.leftover-lozenge.lozenge id=dom_id(leftover, "name") = leftover.name
+  .field.name
+    .leftover-lozenge.lozenge id=dom_id(leftover, "name") = leftover.name
   .field.actions
     = link_to edit_leftover_path(leftover), id: dom_id(leftover, "edit"), class: "icon", data: { turbo_frame: "modal" }
       i.fa-solid.fa-pen

--- a/app/views/plan_days/_plan_day.html.slim
+++ b/app/views/plan_days/_plan_day.html.slim
@@ -1,6 +1,9 @@
-.plan-day
+.plan-day id=dom_id(plan_day)
   .title
     span Day #{plan_day.day_number + 1}
     = link_to "Tags", edit_plan_day_path(plan_day), class: "button", data: { turbo_frame: "modal" }
   .meal
     = plan_day.recipe&.name || "No suitable recipe"
+  .field.tags
+    = render partial: "shared/tag_lozenge", collection: plan_day.tags, as: :tag
+

--- a/app/views/plan_days/update.turbo_stream.slim
+++ b/app/views/plan_days/update.turbo_stream.slim
@@ -1,1 +1,4 @@
+= turbo_stream.replace dom_id(@plan_day) do
+  = render partial: "plan_day", object: @plan_day
+
 = turbo_stream.dispatch "close", target: "modal-inner"

--- a/app/views/recipes/_leftover_fields.html.slim
+++ b/app/views/recipes/_leftover_fields.html.slim
@@ -8,9 +8,9 @@ fieldset.checkboxes.controlled-fieldset
         = lsf.hidden_field :_destroy, data: { controlled_fieldset_target: "destroyField" }
       .controlled-field data-controlled-fieldset-target="controlledField"
         = lsf.collection_radio_buttons :leftover_id, @leftovers, :id, :name do |leftover|
-          .leftover-checkbox
+          .leftover-radio
             = leftover.radio_button
-            = leftover.label
+            .leftover-lozenge.lozenge= leftover.label
       .controlled-field data-controlled-fieldset-target="controlledField"
         .field.short
           = lsf.label :num_days, "For how many days:"
@@ -23,6 +23,6 @@ fieldset.checkboxes.controlled-fieldset
         = lsf.hidden_field :_destroy, data: { controlled_fieldset_target: "destroyField" }
       .controlled-field data-controlled-fieldset-target="controlledField"
         = lsf.collection_radio_buttons :leftover_id, @leftovers, :id, :name do |leftover|
-          .leftover-checkbox
+          .leftover-radio
             = leftover.radio_button
-            = leftover.label
+            .leftover-lozenge.lozenge= leftover.label

--- a/app/views/recipes/_recipe.html.slim
+++ b/app/views/recipes/_recipe.html.slim
@@ -3,6 +3,10 @@
   .field.name id=dom_id(recipe, "name") = recipe.name
   .field.tags
     = render partial: "shared/tag_lozenge", collection: recipe.tags, as: :tag
+    - if recipe.leftovers_source
+      = render partial: "shared/leftover_lozenge", object: recipe.leftovers_source.leftover, as: :leftover, locals: { dir_arrow: "→ " }
+    - if recipe.leftovers_sink
+      = render partial: "shared/leftover_lozenge", object: recipe.leftovers_sink.leftover, as: :leftover, locals: { dir_arrow: "← " }
   .field.actions
     = link_to edit_recipe_path(recipe), id: dom_id(recipe, "edit"), class: "icon", data: { turbo_frame: "modal" }
       i.fa-solid.fa-pen

--- a/app/views/recipes/_recipe.html.slim
+++ b/app/views/recipes/_recipe.html.slim
@@ -1,6 +1,8 @@
 - new_recipe_id ||= nil
 .recipe id=dom_id(recipe) class=("new" if recipe.id == new_recipe_id)
   .field.name id=dom_id(recipe, "name") = recipe.name
+  .field.tags
+    = render partial: "shared/tag_lozenge", collection: recipe.tags, as: :tag
   .field.actions
     = link_to edit_recipe_path(recipe), id: dom_id(recipe, "edit"), class: "icon", data: { turbo_frame: "modal" }
       i.fa-solid.fa-pen

--- a/app/views/shared/_leftover_lozenge.html.slim
+++ b/app/views/shared/_leftover_lozenge.html.slim
@@ -1,1 +1,1 @@
-.leftover-lozenge.lozenge id=dom_id(leftover, "name") = dir_arrow + leftover.name
+.leftover-lozenge.lozenge> id=dom_id(leftover, "name") = dir_arrow + leftover.name

--- a/app/views/shared/_leftover_lozenge.html.slim
+++ b/app/views/shared/_leftover_lozenge.html.slim
@@ -1,0 +1,1 @@
+.leftover-lozenge.lozenge id=dom_id(leftover, "name") = dir_arrow + leftover.name

--- a/app/views/shared/_tag_checkboxes.html.slim
+++ b/app/views/shared/_tag_checkboxes.html.slim
@@ -3,4 +3,4 @@ fieldset.checkboxes
   = f.collection_check_boxes :tag_ids, @tags, :id, :name do |tag|
     .tag-checkbox
       = tag.check_box
-      = tag.label
+      .tag-lozenge.lozenge= tag.label

--- a/app/views/shared/_tag_lozenge.html.slim
+++ b/app/views/shared/_tag_lozenge.html.slim
@@ -1,0 +1,1 @@
+.tag-lozenge.lozenge id=dom_id(tag, "name") = tag.name

--- a/app/views/shared/_tag_lozenge.html.slim
+++ b/app/views/shared/_tag_lozenge.html.slim
@@ -1,1 +1,1 @@
-.tag-lozenge.lozenge id=dom_id(tag, "name") = tag.name
+.tag-lozenge.lozenge> id=dom_id(tag, "name") = tag.name

--- a/app/views/tags/_form.html.slim
+++ b/app/views/tags/_form.html.slim
@@ -1,4 +1,4 @@
-= form_for @tag do |f|
+= form_for @tag, data: { controller: "lozenge-preview" } do |f|
   - if @tag.errors.any?
     #error_explanation
       h2
@@ -7,9 +7,11 @@
         - @tag.errors.full_messages.each do |msg|
           li= msg
 
+  .preview.tag-lozenge.lozenge data-lozenge-preview-target="preview" = @tag.name.presence || "preview"
+
   .field
     .label= f.label :name
-    .input= f.text_field :name, placeholder: "vegetarian", autofocus: true
+    .input= f.text_field :name, placeholder: "vegetarian", autofocus: true, data: { action: "lozenge-preview#nameChange" }
 
   .button-area
     - if !@tag.persisted?

--- a/app/views/tags/_tag.html.slim
+++ b/app/views/tags/_tag.html.slim
@@ -1,6 +1,7 @@
 - new_tag_id ||= nil
 .tag id=dom_id(tag) class=("new" if tag.id == new_tag_id)
-  .field.name.tag-lozenge.lozenge id=dom_id(tag, "name") = tag.name
+  .field.name
+    .tag-lozenge.lozenge id=dom_id(tag, "name") = tag.name
   .field.actions
     = link_to edit_tag_path(tag), id: dom_id(tag, "edit"), class: "icon", data: { turbo_frame: "modal" }
       i.fa-solid.fa-pen

--- a/app/views/tags/_tag.html.slim
+++ b/app/views/tags/_tag.html.slim
@@ -1,6 +1,6 @@
 - new_tag_id ||= nil
 .tag id=dom_id(tag) class=("new" if tag.id == new_tag_id)
-  .field.name id=dom_id(tag, "name") = tag.name
+  .field.name.tag-lozenge.lozenge id=dom_id(tag, "name") = tag.name
   .field.actions
     = link_to edit_tag_path(tag), id: dom_id(tag, "edit"), class: "icon", data: { turbo_frame: "modal" }
       i.fa-solid.fa-pen

--- a/app/views/tags/index.html.slim
+++ b/app/views/tags/index.html.slim
@@ -4,13 +4,13 @@ h1 Tags
   = link_to "Add new leftover", new_leftover_path, class: "button", data: { turbo_frame: "modal" }
   = link_to "Manage recipes", recipes_path, class: "button"
 #list-area
-  #tag-list
+  #tag-list.list
     h2 General tags
     .header-row
       .field.name Name
       .field.actions
     = render partial: "tag", collection: @tags
-  #leftover-list
+  #leftover-list.list
     h2 Leftovers
     .header-row
       .field.name Kind

--- a/spec/features/menu_plans_spec.rb
+++ b/spec/features/menu_plans_spec.rb
@@ -4,6 +4,9 @@ require "rails_helper"
 
 RSpec.feature "menu_plans", js: true do
   let(:user) { create(:user) }
+  let!(:quick_tag) { create(:tag, user:, name: "quick") }
+  let!(:vegetarian_tag) { create(:tag, user:, name: "vegetarian") }
+  let!(:vegan_tag) { create(:tag, user:, name: "vegan") }
   let(:zabaglione) { create(:recipe, user:, name: "Zabaglione") }
   let(:quince_jam) { create(:recipe, user:, name: "Quince jam") }
   let(:lemon_cake) { create(:recipe, user:, name: "Lemon cake") }
@@ -69,6 +72,38 @@ RSpec.feature "menu_plans", js: true do
       expect(page).to have_css(".plan-day", text: "Day 5\nTags\nTiramisu")
       expect(page).to have_css(".plan-day", text: "Day 6\nTags\nNo suitable recipe")
       expect(page).to have_css(".plan-day", text: "Day 7\nTags\nNo suitable recipe")
+    end
+  end
+
+  describe "editing tags on the menu plan" do
+    before { visit "/menu_plan/new" }
+
+    it "shows the tags on the day card" do
+      within(".plan-day:nth-child(1)") do
+        click_on("Tags")
+      end
+
+      within("#modal") do
+        expect(page).to have_text("Edit Day 1")
+        check("quick")
+        check("vegan")
+        click_on("Save and close")
+      end
+
+      expect(page).to have_css(".plan-day:nth-child(1)", text: "quick vegan")
+
+      within(".plan-day:nth-child(3)") do
+        click_on("Tags")
+      end
+
+      within("#modal") do
+        expect(page).to have_text("Edit Day 3")
+        check("vegetarian")
+        check("vegan")
+        click_on("Save and close")
+      end
+
+      expect(page).to have_css(".plan-day:nth-child(3)", text: "vegan vegetarian")
     end
   end
 end

--- a/spec/features/recipes_spec.rb
+++ b/spec/features/recipes_spec.rb
@@ -4,14 +4,14 @@ require "rails_helper"
 
 RSpec.feature "recipes", js: true do
   let(:user) { create(:user) }
-  let!(:zabaglione) { create(:recipe, user:, name: "Zabaglione") }
-  let!(:quince_jam) { create(:recipe, user:, name: "Quince jam") }
-  let!(:lemon_cake) { create(:recipe, user:, name: "Lemon cake") }
   let!(:quick_tag) { create(:tag, user:, name: "quick") }
   let!(:vegetarian_tag) { create(:tag, user:, name: "vegetarian") }
   let!(:vegan_tag) { create(:tag, user:, name: "vegan") }
   let!(:beef_leftovers) { create(:leftover, user:, name: "beef") }
   let!(:pork_leftovers) { create(:leftover, user:, name: "pork") }
+  let!(:zabaglione) { create(:recipe, user:, name: "Zabaglione") }
+  let!(:quince_jam) { create(:recipe, user:, name: "Quince jam", tags: [vegetarian_tag, vegan_tag]) }
+  let!(:lemon_cake) { create(:recipe, user:, name: "Lemon cake", tags: [quick_tag]) }
 
   before do
     allow(Current).to receive(:user).and_return(user)
@@ -23,6 +23,13 @@ RSpec.feature "recipes", js: true do
       expect(page).to have_css(".recipe:nth-child(2) .name", text: "Lemon cake")
       expect(page).to have_css(".recipe:nth-child(3) .name", text: "Quince jam")
       expect(page).to have_css(".recipe:nth-child(4) .name", text: "Zabaglione")
+    end
+
+    it "includes the tags on the recipe line" do
+      visit "/recipes"
+      expect(page).to have_css(".recipe:nth-child(2) .tags", text: "quick")
+      expect(page).to have_css(".recipe:nth-child(3) .tags", text: "vegetarian vegan")
+      expect(page).to have_css(".recipe:nth-child(4) .tags", text: "")
     end
 
     it "lets you add recipes, including errors and tags" do
@@ -55,6 +62,7 @@ RSpec.feature "recipes", js: true do
 
       expect(page).not_to have_css("#modal div")
       expect(page).to have_css(".recipe:nth-child(2) .name", text: "Apple pie")
+      expect(page).to have_css(".recipe:nth-child(2) .tags", text: "quick vegan")
 
       find("##{dom_id(Recipe.last, "edit")}").click
       expect(page).to have_checked_field("quick")
@@ -76,6 +84,9 @@ RSpec.feature "recipes", js: true do
       fill_in("For how many days:", with: 3)
       check("vegan")
       click_on("Save and close")
+
+      expect(page).to have_css(".recipe:nth-child(4) .name", text: "Roast beef")
+      expect(page).to have_css(".recipe:nth-child(4) .tags", text: "vegan → beef")
 
       find("##{dom_id(Recipe.last, "edit")}").click
       expect(page).to have_checked_field("vegan")
@@ -117,6 +128,9 @@ RSpec.feature "recipes", js: true do
       check("Uses leftovers")
       choose("beef")
       click_on("Save and close")
+
+      expect(page).to have_css(".recipe:nth-child(4) .name", text: "Roast beef")
+      expect(page).to have_css(".recipe:nth-child(4) .tags", text: "← beef")
 
       find("##{dom_id(Recipe.last, "edit")}").click
       expect(page).to have_checked_field("Uses leftovers")

--- a/spec/features/tags_spec.rb
+++ b/spec/features/tags_spec.rb
@@ -76,5 +76,16 @@ RSpec.feature "tags", js: true do
       expect(page).not_to have_css("##{dom_id(vegan)}")
       expect(Tag.count).to eq 2
     end
+
+    it "previews the tag on the edit modal" do
+      visit "/tags"
+      click_link "Add new tag"
+
+      within("#modal") do
+        expect(page).to have_css(".tag-lozenge", text: "preview")
+        fill_in("Name", with: "favourite")
+        expect(page).to have_css(".tag-lozenge", text: "favourite")
+      end
+    end
   end
 end


### PR DESCRIPTION
Display tags and leftovers as grey lozenges pretty much everywhere:
* On their index page, show them as lozenges
* On the recipes index, show them as lozenges at the end of the line
* On the menu plan view, show the ones set as restrictions at the bottom of each day

Tags are (currently) black-on-pale; leftovers are white-on-dark. On the recipes index, leftovers lozenges have an arrow indicating leftover source vs sink.

TODO: Lozenges in the recipe / plan day forms.
QUESTION: Should the plan day _also_ show lozenges for the recipe that's there?